### PR TITLE
alter query condition in order to always run WHERE-LIKE

### DIFF
--- a/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Input.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Input.php
@@ -50,13 +50,11 @@ class Input implements LevelDefinitionInterface
         $db = Db::get();
 
         // create condition
-        $where = $this->condition == '' ? 1 : $this->condition;
+        $where = $this->condition == '' ? 1 : $db->getWrappedConnection()->quote("%".$this->condition."%");
         if ($condition) {
-            $where = "LIKE '%$where%'";
+            $where = ' LIKE ' . $where;
             $where .= ' AND ' . $condition;
         }
-        // TODO: this is such a bonkers way to pass down values.
-        // When ViCA is built, we have to do this clean and simple.
 
         // create query
         $sql = 'SELECT SQL_CALC_FOUND_ROWS %1$s as "value", %1$s as "label", count(*) as "count"

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Input.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Input.php
@@ -52,7 +52,7 @@ class Input implements LevelDefinitionInterface
         // create condition
         $where = $this->condition == '' ? 1 : $this->condition;
         if ($condition) {
-            $where = 'LIKE \'%'.$where.'%\'';
+            $where = "LIKE '%$where%'";
             $where .= ' AND ' . $condition;
         }
         // TODO: this is such a bonkers way to pass down values.

--- a/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Input.php
+++ b/src/Elements/Bundle/AlternateObjectTreesBundle/LevelDefinition/Input.php
@@ -52,15 +52,19 @@ class Input implements LevelDefinitionInterface
         // create condition
         $where = $this->condition == '' ? 1 : $this->condition;
         if ($condition) {
+            $where = 'LIKE \'%'.$where.'%\'';
             $where .= ' AND ' . $condition;
         }
+        // TODO: this is such a bonkers way to pass down values.
+        // When ViCA is built, we have to do this clean and simple.
 
         // create query
         $sql = 'SELECT SQL_CALC_FOUND_ROWS %1$s as "value", %1$s as "label", count(*) as "count"
                 FROM object_%2$s
-                WHERE %3$s
+                WHERE object_%2$s.%1$s %3$s
                 GROUP BY %1$s
                 ORDER BY %1$s';
+
         if ($offset && $limit) {
             $sql .= sprintf(' LIMIT %d, %d', $offset, $limit);
         }


### PR DESCRIPTION
this a very stupid way to do things but i'm beginning to get tried with finding a balance on making the right change without having to refine and reformat everything.

the base request is this: we need a proof of context for a prototype that will be demonstrated.

there is a `field` input and a `condition` input (among others). and in `condition` the end user had to actually write the SQL syntax of a condition.
the result we wanted is to change the mechanism in a way that the user just writes a string in the `condition` input, and the default function executes the query with a `WHERE [field] LIKE [string]`

in their code they pass down their values with a shitty JS and then they add their own conditions and the cascade everything into one var.
to do this properly i would have to actually break their functionalities into better code and add the SQL syntax in the actual SQL var. but since my goal is to actually do only a proof of context, i decided to go where they cascade the conditions and change the grammar.
**I don't like it**. if there is a slightly better way to do this let me know, i just don't want to spend much more time on their code at this point.

the longer term goal is to make our own bundle, and i would definitely plan things differently there.